### PR TITLE
chore: remove load methods redundancy

### DIFF
--- a/config/json/config.go
+++ b/config/json/config.go
@@ -21,30 +21,7 @@ func Load(filePath string) (config.Config, error) {
 	}
 	_ = file.Close()
 
-	cfg := config.Config{
-		MySql: config.Database{
-			MigrationsPath: config.DefaultMigrationsMysql,
-		},
-		MongoDb: config.Database{
-			MigrationsPath: config.DefaultMigrationsMongo,
-		},
-		Postgres: config.Database{
-			MigrationsPath: config.DefaultMigrationsPostgres,
-		},
-		Token: config.Token{
-			MaxAge: config.DefaultSessionMaxAge,
-		},
-		Tracer: config.Tracer{
-			JaegerHost: config.DefaultJaegerHost,
-		},
-	}
-
-	err = json.Unmarshal(bytes, &cfg)
-	if err != nil {
-		return config.Config{}, err
-	}
-
-	return cfg, nil
+	return LoadContent(bytes)
 }
 
 // LoadContent loads configurations from a given json bytes content.

--- a/config/toml/config.go
+++ b/config/toml/config.go
@@ -22,30 +22,7 @@ func Load(filePath string) (config.Config, error) {
 	}
 	_ = file.Close()
 
-	cfg := config.Config{
-		MySql: config.Database{
-			MigrationsPath: config.DefaultMigrationsMysql,
-		},
-		MongoDb: config.Database{
-			MigrationsPath: config.DefaultMigrationsMongo,
-		},
-		Postgres: config.Database{
-			MigrationsPath: config.DefaultMigrationsPostgres,
-		},
-		Token: config.Token{
-			MaxAge: config.DefaultSessionMaxAge,
-		},
-		Tracer: config.Tracer{
-			JaegerHost: config.DefaultJaegerHost,
-		},
-	}
-
-	err = toml.Unmarshal(bytes, &cfg)
-	if err != nil {
-		return config.Config{}, err
-	}
-
-	return cfg, nil
+	return LoadContent(bytes)
 }
 
 // LoadContent loads configurations from a given toml bytes content.

--- a/config/xml/config.go
+++ b/config/xml/config.go
@@ -21,30 +21,7 @@ func Load(filePath string) (config.Config, error) {
 	}
 	_ = file.Close()
 
-	cfg := config.Config{
-		MySql: config.Database{
-			MigrationsPath: config.DefaultMigrationsMysql,
-		},
-		MongoDb: config.Database{
-			MigrationsPath: config.DefaultMigrationsMongo,
-		},
-		Postgres: config.Database{
-			MigrationsPath: config.DefaultMigrationsPostgres,
-		},
-		Token: config.Token{
-			MaxAge: config.DefaultSessionMaxAge,
-		},
-		Tracer: config.Tracer{
-			JaegerHost: config.DefaultJaegerHost,
-		},
-	}
-
-	err = xml.Unmarshal(bytes, &cfg)
-	if err != nil {
-		return config.Config{}, err
-	}
-
-	return cfg, nil
+	return LoadContent(bytes)
 }
 
 // LoadContent loads configurations from a given xml bytes content.

--- a/config/xml/config_test.go
+++ b/config/xml/config_test.go
@@ -280,7 +280,7 @@ func TestLoadContent(t *testing.T) {
 func createTempFile(t *testing.T, fileContent string) *os.File {
 	t.Helper()
 
-	tempFile, err := os.CreateTemp("", "test.toml")
+	tempFile, err := os.CreateTemp("", "test.xml")
 	require.NoError(t, err)
 
 	_, err = tempFile.WriteString(fileContent)

--- a/config/yaml/config.go
+++ b/config/yaml/config.go
@@ -22,30 +22,7 @@ func Load(filePath string) (config.Config, error) {
 	}
 	_ = file.Close()
 
-	cfg := config.Config{
-		MySql: config.Database{
-			MigrationsPath: config.DefaultMigrationsMysql,
-		},
-		MongoDb: config.Database{
-			MigrationsPath: config.DefaultMigrationsMongo,
-		},
-		Postgres: config.Database{
-			MigrationsPath: config.DefaultMigrationsPostgres,
-		},
-		Token: config.Token{
-			MaxAge: config.DefaultSessionMaxAge,
-		},
-		Tracer: config.Tracer{
-			JaegerHost: config.DefaultJaegerHost,
-		},
-	}
-
-	err = yaml.Unmarshal(bytes, &cfg)
-	if err != nil {
-		return config.Config{}, err
-	}
-
-	return cfg, nil
+	return LoadContent(bytes)
 }
 
 // LoadContent loads configurations from a given yaml bytes content.


### PR DESCRIPTION
## Changes
* Encapsulate `LoadContent` methods into `Load` to avoid redundancy.