### PR TITLE
chore: update golang to 1.20 version

### DIFF
--- a/.github/workflows/test-and-lint.yml
+++ b/.github/workflows/test-and-lint.yml
@@ -13,15 +13,18 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
       - name: Install Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
-          go-version: 1.19
+          go-version: "1.20"
+          cache: true
 
       - name: Install mockgen
-        run: go install go.uber.org/mock/mockgen@latest
+        run: go install go.uber.org/mock/mockgen@v0.4.0
 
-      - uses: actions/checkout@v3
       - name: Generate
         run: go generate ./...
 
@@ -40,15 +43,18 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
       - name: Install Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
-          go-version: 1.19
+          go-version: "1.20"
+          cache: true
 
       - name: Install mockgen
-        run: go install go.uber.org/mock/mockgen@latest
+        run: go install go.uber.org/mock/mockgen@v0.4.0
 
-      - uses: actions/checkout@v3
       - name: Generate
         run: go generate ./...
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ribeirohugo/go_config
 
-go 1.19
+go 1.20
 
 require (
 	github.com/BurntSushi/toml v1.3.2

--- a/go.mod
+++ b/go.mod
@@ -5,10 +5,10 @@ go 1.20
 require (
 	github.com/BurntSushi/toml v1.3.2
 	github.com/stretchr/testify v1.8.4
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )


### PR DESCRIPTION
## Changes
* Update Go version to `1.20`.
* Update `test-and-lint.yml` to use Go 1.20 version.
* Update `test-and-lint.yml` `actions/setup-go` to `v5`.
* Add cache to `Install Go` step in `test-and-lint.yml`.
* Update `test-and-lint.yml`  `actions/checkout` to `v4`.
* Update `test-and-lint.yml` checkout order.
