### PR TITLE
feat: add default database ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Then, data can be loaded by calling `Load` method.
 It supports a `config.toml` file properly fulfilled.
 
 ```
-cfg, err := toml.Load(configFile)
+cfg, err := env.Load(configFile)
 if err != nil {
     log.Fatal(err)
 }

--- a/README.md
+++ b/README.md
@@ -38,8 +38,10 @@ To set up ``[mysql]`` and ``[postgres]`` use the following parameters:
 | ``host``            | Database host.                                      | `string` | ` `                                          | **YES**  |
 | ``migrations_path`` | Migrations directory path.                          | `string` | `file://migrations/<mongo><mysql><postgres>` | **NO**   |
 | ``password``        | Database password.                                  | `string` | ` `                                          | **YES**  |
-| ``port``            | Database port.                                      | `int`    | ` `                                          | **YES**  |
+| ``port``            | Database port.                                      | `int`    | `3306`, `5432`, `27017` <sup>(1)</sup>       | **YES**  |
 | ``user``            | Database user with needed privileges over database. | `string` | ` `                                          | **YES**  |
+
+> <sup>(1)</sup> `3306` for MySQL, `5432` for Postgres and `27017` for MongoDB. 
 
 ### 1.3. Token type
 

--- a/config/consts.go
+++ b/config/consts.go
@@ -4,7 +4,9 @@ const (
 	DefaultMigrationsMongo    = "file://migrations/mongo"
 	DefaultMigrationsMysql    = "file://migrations/mysql"
 	DefaultMigrationsPostgres = "file://migrations/postgres"
+	DefaultMongoPort          = 27017
+	DefaultMySqlPort          = 3306
+	DefaultPostgresPort       = 5432
 	DefaultSessionMaxAge      = 86400 // 24 hours
-
-	DefaultJaegerHost = "http://localhost:14268/api/traces"
+	DefaultJaegerHost         = "http://localhost:14268/api/traces"
 )

--- a/config/env/config.go
+++ b/config/env/config.go
@@ -46,7 +46,7 @@ func Load() (config.Config, error) {
 	if mongoDBMigrationsPath == "" {
 		mongoDBMigrationsPath = config.DefaultMigrationsMongo
 	}
-	mongoDBPort, err := getNumber("MONGODB_PORT", defaultInt)
+	mongoDBPort, err := getNumber("MONGODB_PORT", config.DefaultMongoPort)
 	if err != nil {
 		return config.Config{}, err
 	}
@@ -54,7 +54,7 @@ func Load() (config.Config, error) {
 	if mySQLMigrationsPath == "" {
 		mySQLMigrationsPath = config.DefaultMigrationsMysql
 	}
-	mySQLPort, err := getNumber("MYSQL_PORT", defaultInt)
+	mySQLPort, err := getNumber("MYSQL_PORT", config.DefaultMySqlPort)
 	if err != nil {
 		return config.Config{}, err
 	}
@@ -62,7 +62,7 @@ func Load() (config.Config, error) {
 	if postgresMigrationsPath == "" {
 		postgresMigrationsPath = config.DefaultMigrationsPostgres
 	}
-	postgresPort, err := getNumber("POSTGRES_PORT", defaultInt)
+	postgresPort, err := getNumber("POSTGRES_PORT", config.DefaultPostgresPort)
 	if err != nil {
 		return config.Config{}, err
 	}

--- a/config/env/config_test.go
+++ b/config/env/config_test.go
@@ -202,12 +202,15 @@ func TestLoad(t *testing.T) {
 	t.Run("without optional fields", func(t *testing.T) {
 		expectedConfig := config.Config{
 			MySql: config.Database{
+				Port:           config.DefaultMySqlPort,
 				MigrationsPath: config.DefaultMigrationsMysql,
 			},
 			MongoDb: config.Database{
+				Port:           config.DefaultMongoPort,
 				MigrationsPath: config.DefaultMigrationsMongo,
 			},
 			Postgres: config.Database{
+				Port:           config.DefaultPostgresPort,
 				MigrationsPath: config.DefaultMigrationsPostgres,
 			},
 			Tracer: config.Tracer{

--- a/config/json/config.go
+++ b/config/json/config.go
@@ -28,12 +28,15 @@ func Load(filePath string) (config.Config, error) {
 func LoadContent(content []byte) (config.Config, error) {
 	cfg := config.Config{
 		MySql: config.Database{
+			Port:           config.DefaultMySqlPort,
 			MigrationsPath: config.DefaultMigrationsMysql,
 		},
 		MongoDb: config.Database{
+			Port:           config.DefaultMongoPort,
 			MigrationsPath: config.DefaultMigrationsMongo,
 		},
 		Postgres: config.Database{
+			Port:           config.DefaultPostgresPort,
 			MigrationsPath: config.DefaultMigrationsPostgres,
 		},
 		Token: config.Token{

--- a/config/json/config_test.go
+++ b/config/json/config_test.go
@@ -135,12 +135,15 @@ func TestLoad(t *testing.T) {
 		t.Run("without optional fields", func(t *testing.T) {
 			expectedConfig := config.Config{
 				MySql: config.Database{
+					Port:           config.DefaultMySqlPort,
 					MigrationsPath: config.DefaultMigrationsMysql,
 				},
 				MongoDb: config.Database{
+					Port:           config.DefaultMongoPort,
 					MigrationsPath: config.DefaultMigrationsMongo,
 				},
 				Postgres: config.Database{
+					Port:           config.DefaultPostgresPort,
 					MigrationsPath: config.DefaultMigrationsPostgres,
 				},
 				Audit: config.Audit{
@@ -253,12 +256,15 @@ func TestLoadContent(t *testing.T) {
 		t.Run("without optional fields", func(t *testing.T) {
 			expectedConfig := config.Config{
 				MySql: config.Database{
+					Port:           config.DefaultMySqlPort,
 					MigrationsPath: config.DefaultMigrationsMysql,
 				},
 				MongoDb: config.Database{
+					Port:           config.DefaultMongoPort,
 					MigrationsPath: config.DefaultMigrationsMongo,
 				},
 				Postgres: config.Database{
+					Port:           config.DefaultPostgresPort,
 					MigrationsPath: config.DefaultMigrationsPostgres,
 				},
 				Tracer: config.Tracer{

--- a/config/toml/config.go
+++ b/config/toml/config.go
@@ -29,12 +29,15 @@ func Load(filePath string) (config.Config, error) {
 func LoadContent(content []byte) (config.Config, error) {
 	cfg := config.Config{
 		MySql: config.Database{
+			Port:           config.DefaultMySqlPort,
 			MigrationsPath: config.DefaultMigrationsMysql,
 		},
 		MongoDb: config.Database{
+			Port:           config.DefaultMongoPort,
 			MigrationsPath: config.DefaultMigrationsMongo,
 		},
 		Postgres: config.Database{
+			Port:           config.DefaultPostgresPort,
 			MigrationsPath: config.DefaultMigrationsPostgres,
 		},
 		Token: config.Token{

--- a/config/toml/config_test.go
+++ b/config/toml/config_test.go
@@ -132,12 +132,15 @@ func TestLoad(t *testing.T) {
 		t.Run("without optional fields", func(t *testing.T) {
 			expectedConfig := config.Config{
 				MySql: config.Database{
+					Port:           config.DefaultMySqlPort,
 					MigrationsPath: config.DefaultMigrationsMysql,
 				},
 				MongoDb: config.Database{
+					Port:           config.DefaultMongoPort,
 					MigrationsPath: config.DefaultMigrationsMongo,
 				},
 				Postgres: config.Database{
+					Port:           config.DefaultPostgresPort,
 					MigrationsPath: config.DefaultMigrationsPostgres,
 				},
 				Tracer: config.Tracer{
@@ -246,12 +249,15 @@ func TestLoadContent(t *testing.T) {
 		t.Run("without optional fields", func(t *testing.T) {
 			expectedConfig := config.Config{
 				MySql: config.Database{
+					Port:           config.DefaultMySqlPort,
 					MigrationsPath: config.DefaultMigrationsMysql,
 				},
 				MongoDb: config.Database{
+					Port:           config.DefaultMongoPort,
 					MigrationsPath: config.DefaultMigrationsMongo,
 				},
 				Postgres: config.Database{
+					Port:           config.DefaultPostgresPort,
 					MigrationsPath: config.DefaultMigrationsPostgres,
 				},
 				Tracer: config.Tracer{

--- a/config/xml/config.go
+++ b/config/xml/config.go
@@ -28,12 +28,15 @@ func Load(filePath string) (config.Config, error) {
 func LoadContent(content []byte) (config.Config, error) {
 	cfg := config.Config{
 		MySql: config.Database{
+			Port:           config.DefaultMySqlPort,
 			MigrationsPath: config.DefaultMigrationsMysql,
 		},
 		MongoDb: config.Database{
+			Port:           config.DefaultMongoPort,
 			MigrationsPath: config.DefaultMigrationsMongo,
 		},
 		Postgres: config.Database{
+			Port:           config.DefaultPostgresPort,
 			MigrationsPath: config.DefaultMigrationsPostgres,
 		},
 		Token: config.Token{

--- a/config/xml/config_test.go
+++ b/config/xml/config_test.go
@@ -146,12 +146,15 @@ func TestLoad(t *testing.T) {
 					Local: xmlLocalName,
 				},
 				MySql: config.Database{
+					Port:           config.DefaultMySqlPort,
 					MigrationsPath: config.DefaultMigrationsMysql,
 				},
 				MongoDb: config.Database{
+					Port:           config.DefaultMongoPort,
 					MigrationsPath: config.DefaultMigrationsMongo,
 				},
 				Postgres: config.Database{
+					Port:           config.DefaultPostgresPort,
 					MigrationsPath: config.DefaultMigrationsPostgres,
 				},
 				Tracer: config.Tracer{
@@ -267,12 +270,15 @@ func TestLoadContent(t *testing.T) {
 					Local: xmlLocalName,
 				},
 				MySql: config.Database{
+					Port:           config.DefaultMySqlPort,
 					MigrationsPath: config.DefaultMigrationsMysql,
 				},
 				MongoDb: config.Database{
+					Port:           config.DefaultMongoPort,
 					MigrationsPath: config.DefaultMigrationsMongo,
 				},
 				Postgres: config.Database{
+					Port:           config.DefaultPostgresPort,
 					MigrationsPath: config.DefaultMigrationsPostgres,
 				},
 				Tracer: config.Tracer{

--- a/config/yaml/config.go
+++ b/config/yaml/config.go
@@ -29,12 +29,15 @@ func Load(filePath string) (config.Config, error) {
 func LoadContent(content []byte) (config.Config, error) {
 	cfg := config.Config{
 		MySql: config.Database{
+			Port:           config.DefaultMySqlPort,
 			MigrationsPath: config.DefaultMigrationsMysql,
 		},
 		MongoDb: config.Database{
+			Port:           config.DefaultMongoPort,
 			MigrationsPath: config.DefaultMigrationsMongo,
 		},
 		Postgres: config.Database{
+			Port:           config.DefaultPostgresPort,
 			MigrationsPath: config.DefaultMigrationsPostgres,
 		},
 		Token: config.Token{

--- a/config/yaml/config_test.go
+++ b/config/yaml/config_test.go
@@ -132,12 +132,15 @@ func TestLoadYaml(t *testing.T) {
 		t.Run("without optional fields", func(t *testing.T) {
 			expectedConfig := config.Config{
 				MySql: config.Database{
+					Port:           config.DefaultMySqlPort,
 					MigrationsPath: config.DefaultMigrationsMysql,
 				},
 				MongoDb: config.Database{
+					Port:           config.DefaultMongoPort,
 					MigrationsPath: config.DefaultMigrationsMongo,
 				},
 				Postgres: config.Database{
+					Port:           config.DefaultPostgresPort,
 					MigrationsPath: config.DefaultMigrationsPostgres,
 				},
 				Tracer: config.Tracer{
@@ -246,12 +249,15 @@ func TestLoadContent(t *testing.T) {
 		t.Run("without optional fields", func(t *testing.T) {
 			expectedConfig := config.Config{
 				MySql: config.Database{
+					Port:           config.DefaultMySqlPort,
 					MigrationsPath: config.DefaultMigrationsMysql,
 				},
 				MongoDb: config.Database{
+					Port:           config.DefaultMongoPort,
 					MigrationsPath: config.DefaultMigrationsMongo,
 				},
 				Postgres: config.Database{
+					Port:           config.DefaultPostgresPort,
 					MigrationsPath: config.DefaultMigrationsPostgres,
 				},
 				Tracer: config.Tracer{

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/ribeirohugo/go_config
 go 1.22
 
 require (
-	github.com/BurntSushi/toml v1.3.2
+	github.com/BurntSushi/toml v1.4.0
 	github.com/stretchr/testify v1.9.0
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/BurntSushi/toml v1.3.2 h1:o7IhLm0Msx3BaB+n3Ag7L8EVlByGnpq14C4YWiu/gL8=
-github.com/BurntSushi/toml v1.3.2/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
+github.com/BurntSushi/toml v1.4.0 h1:kuoIxZQy2WRRk1pttg9asf+WVv6tWQuBNVmK8+nqPr0=
+github.com/BurntSushi/toml v1.4.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=


### PR DESCRIPTION
## Changes
* Add `Mongo`, `MySQL` and `Postgres` default database port constants.
* Update `BurntSushi/toml` dependency to `v1.4.0`.