### PR TITLE
chore: refactor external service structs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@ Check out the following tables to know all ``Config`` parameters detailed.
 
 | Parameter       | Description                           | Type              | Default | Required |
 |:----------------|:--------------------------------------|:------------------|:--------|:---------|
-| ``environment`` | Website environment.                  | `string`          | ` `     | **YES**  |
-| ``service``     | Website service identifier as string. | `string`          | ` `     | **YES**  |
+| ``environment`` | Website environment.                  | `string`          | ` `     | **NO**   |
+| ``service``     | Website service identifier as string. | `string`          | ` `     | **NO**   |
 | ``[server]``    | Http server config data.              | `Server`          | ` `     | **YES**  |
-| ``[token]``     | Token data config data.               | `Token`           | ` `     | **YES**  |
-| ``[mongodb]``   | Postgres database config data.        | `Database`        | ` `     | **YES**  |
-| ``[mysql]``     | MySql database config data.           | `Database`        | ` `     | **YES**  |
-| ``[postgres]``  | Postgres database config data.        | `Database`        | ` `     | **YES**  |
+| ``[token]``     | Token data config data.               | `Token`           | ` `     | **NO**   |
+| ``[mongodb]``   | Postgres database config data.        | `Database`        | ` `     | **NO**   |
+| ``[mysql]``     | MySql database config data.           | `Database`        | ` `     | **NO**   |
+| ``[postgres]``  | Postgres database config data.        | `Database`        | ` `     | **NO**   |
 | ``[audit]``     | Auditing options config data.         | `ExternalService` | ` `     | **NO**   |
 | ``[jaeger]``    | Jaeger tracing options config data.   | `ExternalService` | ` `     | **NO**   |
 | ``[loki]``      | Grafana Loki options config data.     | `ExternalService` | ` `     | **NO**   |

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ Check out the following tables to know all ``Config`` parameters detailed.
 | ``[mongodb]``   | Postgres database config data.        | `Database`        | ` `     | **YES**  |
 | ``[mysql]``     | MySql database config data.           | `Database`        | ` `     | **YES**  |
 | ``[postgres]``  | Postgres database config data.        | `Database`        | ` `     | **YES**  |
-| ``[audit]``     | Auditing options config data.         | `Audit`           | ` `     | **YES**  |
+| ``[audit]``     | Auditing options config data.         | `ExternalService` | ` `     | **NO**   |
+| ``[jaeger]``    | Jaeger tracing options config data.   | `ExternalService` | ` `     | **NO**   |
 | ``[loki]``      | Grafana Loki options config data.     | `ExternalService` | ` `     | **NO**   |
-| ``[tracer]``    | Tracing options config data.          | `Tracer`          | ` `     | **YES**  |
 
 ### 1.1. Server type
 
@@ -51,23 +51,7 @@ To set up ``[mysql]`` and ``[postgres]`` use the following parameters:
 | ``secret``     | Website token secret string.              | `string` | ` `      | **YES**  |
 | ``max_age``    | Maximum duration of a token (in seconds). | `int`    | `86400`  | **NO**   |
 
-### 1.4. Audit type
-
-| Parameter  | Description                       | Type     | Default | Required |
-|:-----------|:----------------------------------|:---------|:--------|:---------|
-| ``Enable`` | Enable flag to activate auditing. | `bool`   | `FALSE` | **NO**   |
-| ``Host``   | Auditing server host address.     | `string` | ` `     | **NO**   |
-
-
-### 1.5. Tracer type
-
-| Parameter      | Description                           | Type     | Default                             | Required |
-|:---------------|:--------------------------------------|:---------|:------------------------------------|:---------|
-| ``Enable``     | Enable flag to activate tracing.      | `bool`   | `FALSE`                             | **NO**   |
-| ``JaegerHost`` | ** Deprecated ** Jaeger host address. | `string` | `http://localhost:14268/api/traces` | **NO**   |
-| ``Host``       | Tracer host address.                  | `string` | ` `                                 | **NO**   |
-
-### 1.6. External Service type
+### 1.4. External Service type
 
 | Parameter  | Description                      | Type     | Default            | Required |
 |:-----------|:---------------------------------|:---------|:-------------------|:---------|
@@ -77,14 +61,16 @@ To set up ``[mysql]`` and ``[postgres]`` use the following parameters:
 
 > <sup>(2)</sup> Host default values are specified in `External Host Default Values` table.
 
-### 1.6.1. External Host Default Values
+### 1.4.1. External Host Default Values
 
 For `ExternalService` main config, the `Host` default value depends on the main service,
 and those values are described in the next table.
 
-| Service  | Default Host Value                       |
-|:---------|:-----------------------------------------|
-| ``Loki`` | `http://localhost:3100/loki/api/v1/push` |
+| Service    | Default Host Value                       |
+|:-----------|:-----------------------------------------|
+| ``Audit``  | ` `                                      |
+| ``Jaeger`` | `http://localhost:14268/api/traces`      |
+| ``Loki``   | `http://localhost:3100/loki/api/v1/push` |
 
 ## 2. Load data
 

--- a/config.toml
+++ b/config.toml
@@ -31,5 +31,11 @@ password = "password"
 port = 3306
 user = "username"
 
-[tracer]
+[audit]
+enabled = false
+
+[jaeger]
+enabled = false
+
+[loki]
 enabled = false

--- a/config/env/config.go
+++ b/config/env/config.go
@@ -40,13 +40,13 @@ func Load() (config.Config, error) {
 	if lokiHost == "" {
 		lokiHost = config.DefaultLokiHost
 	}
-	tracerEnabled, err := getBool("TRACER_ENABLED")
+	jaegerEnabled, err := getBool("JAEGER_ENABLED")
 	if err != nil {
 		return config.Config{}, err
 	}
-	tracerJaegerHost := os.Getenv("TRACER_JAEGER_HOST")
-	if tracerJaegerHost == "" {
-		tracerJaegerHost = config.DefaultJaegerHost
+	jaegerHost := os.Getenv("JAEGER_HOST")
+	if jaegerHost == "" {
+		jaegerHost = config.DefaultJaegerHost
 	}
 
 	// Load Defaults
@@ -110,19 +110,20 @@ func Load() (config.Config, error) {
 			Db:             os.Getenv("POSTGRES_DATABASE"),
 			MigrationsPath: postgresMigrationsPath,
 		},
-		Audit: config.Audit{
+		Audit: config.ExternalService{
 			Enabled: auditEnabled,
 			Host:    os.Getenv("AUDIT_HOST"),
+			Token:   os.Getenv("AUDIT_TOKEN"),
 		},
 		Loki: config.ExternalService{
 			Enabled: lokiEnabled,
 			Host:    lokiHost,
 			Token:   os.Getenv("LOKI_TOKEN"),
 		},
-		Tracer: config.Tracer{
-			Enabled:    tracerEnabled,
-			Host:       os.Getenv("TRACER_HOST"),
-			JaegerHost: tracerJaegerHost,
+		Jaeger: config.ExternalService{
+			Enabled: jaegerEnabled,
+			Host:    jaegerHost,
+			Token:   os.Getenv("LOKI_TOKEN"),
 		},
 		Environment: os.Getenv("ENVIRONMENT"),
 		Service:     os.Getenv("SERVICE"),

--- a/config/env/config_test.go
+++ b/config/env/config_test.go
@@ -58,9 +58,11 @@ func TestLoad(t *testing.T) {
 		password    = "password"
 		username    = "username"
 		auditHost   = "audit.domain"
+		auditToken  = "audit.token"
 		lokiHost    = "loki.domain"
 		lokiToken   = "loki.token"
-		tracerHost  = "https://tracer.domain"
+		jaegerHost  = "https://tracer.domain"
+		jaegerToken = "loki.token"
 	)
 	expectedCfg := config.Config{
 		Server: config.Server{
@@ -96,19 +98,20 @@ func TestLoad(t *testing.T) {
 			Db:             database,
 			MigrationsPath: config.DefaultMigrationsPostgres,
 		},
-		Audit: config.Audit{
+		Audit: config.ExternalService{
 			Enabled: true,
 			Host:    auditHost,
+			Token:   auditToken,
 		},
 		Loki: config.ExternalService{
 			Enabled: true,
 			Host:    lokiHost,
 			Token:   lokiToken,
 		},
-		Tracer: config.Tracer{
-			Enabled:    true,
-			JaegerHost: tracerHost,
-			Host:       tracerHost,
+		Jaeger: config.ExternalService{
+			Enabled: true,
+			Host:    jaegerHost,
+			Token:   jaegerToken,
 		},
 		Environment: environment,
 		Service:     service,
@@ -159,17 +162,19 @@ func TestLoad(t *testing.T) {
 		require.NoError(t, err)
 		err = os.Setenv("AUDIT_HOST", auditHost)
 		require.NoError(t, err)
+		err = os.Setenv("AUDIT_TOKEN", auditToken)
+		require.NoError(t, err)
 		err = os.Setenv("LOKI_ENABLED", "TRUE")
 		require.NoError(t, err)
 		err = os.Setenv("LOKI_HOST", lokiHost)
 		require.NoError(t, err)
 		err = os.Setenv("LOKI_TOKEN", lokiToken)
 		require.NoError(t, err)
-		err = os.Setenv("TRACER_ENABLED", "TRUE")
+		err = os.Setenv("JAEGER_ENABLED", "TRUE")
 		require.NoError(t, err)
-		err = os.Setenv("TRACER_HOST", tracerHost)
+		err = os.Setenv("JAEGER_HOST", jaegerHost)
 		require.NoError(t, err)
-		err = os.Setenv("TRACER_JAEGER_HOST", tracerHost)
+		err = os.Setenv("JAEGER_TOKEN", jaegerToken)
 		require.NoError(t, err)
 		err = os.Setenv("SERVICE", service)
 		require.NoError(t, err)
@@ -199,12 +204,13 @@ func TestLoad(t *testing.T) {
 				"POSTGRES_DATABASE",
 				"AUDIT_ENABLED",
 				"AUDIT_HOST",
+				"AUDIT_TOKEN",
 				"LOKI_ENABLED",
 				"LOKI_HOST",
 				"LOKI_TOKEN",
-				"TRACER_ENABLED",
-				"TRACER_HOST",
-				"TRACER_JAEGER_HOST",
+				"JAEGER_ENABLED",
+				"JAEGER_HOST",
+				"JAEGER_TOKEN",
 				"SERVICE",
 				"ENVIRONMENT",
 			)
@@ -232,8 +238,8 @@ func TestLoad(t *testing.T) {
 			Loki: config.ExternalService{
 				Host: config.DefaultLokiHost,
 			},
-			Tracer: config.Tracer{
-				JaegerHost: config.DefaultJaegerHost,
+			Jaeger: config.ExternalService{
+				Host: config.DefaultJaegerHost,
 			},
 			Token: config.Token{
 				MaxAge: config.DefaultSessionMaxAge,
@@ -257,10 +263,10 @@ func TestLoad(t *testing.T) {
 			assert.Error(t, err)
 		})
 		t.Run("due to invalid bool value", func(t *testing.T) {
-			err := os.Setenv("TRACER_ENABLED", "error")
+			err := os.Setenv("JAEGER_ENABLED", "error")
 			require.NoError(t, err)
 			defer func() {
-				err = os.Unsetenv("TRACER_ENABLED")
+				err = os.Unsetenv("JAEGER_ENABLED")
 				require.NoError(t, err)
 			}()
 			_, err = Load()

--- a/config/env/config_test.go
+++ b/config/env/config_test.go
@@ -61,7 +61,7 @@ func TestLoad(t *testing.T) {
 		auditToken  = "audit.token"
 		lokiHost    = "loki.domain"
 		lokiToken   = "loki.token"
-		jaegerHost  = "https://tracer.domain"
+		jaegerHost  = "jaeger.domain"
 		jaegerToken = "loki.token"
 	)
 	expectedCfg := config.Config{

--- a/config/json/config.go
+++ b/config/json/config.go
@@ -45,8 +45,8 @@ func LoadContent(content []byte) (config.Config, error) {
 		Loki: config.ExternalService{
 			Host: config.DefaultLokiHost,
 		},
-		Tracer: config.Tracer{
-			JaegerHost: config.DefaultJaegerHost,
+		Jaeger: config.ExternalService{
+			Host: config.DefaultJaegerHost,
 		},
 	}
 

--- a/config/json/config_test.go
+++ b/config/json/config_test.go
@@ -45,17 +45,18 @@ const configContent = `{
   },
   "audit": {
     "enabled": true,
-    "host": "audit.domain"
+    "host": "audit.domain",
+    "token": "audit.token"
   },
   "loki": {
     "enabled": true,
     "host": "loki.domain",
     "token": "loki.token"
   },
-  "tracer": {
+  "jaeger": {
     "enabled": true,
-    "jaeger_host": "https://tracer.domain",
-    "host": "https://tracer.domain"
+    "host": "jaeger.domain",
+    "token": "jaeger.token"
   }
 }`
 
@@ -77,9 +78,11 @@ func TestLoad(t *testing.T) {
 		password    = "password"
 		username    = "username"
 		auditHost   = "audit.domain"
+		auditToken  = "audit.token"
 		lokiHost    = "loki.domain"
 		lokiToken   = "loki.token"
-		tracerHost  = "https://tracer.domain"
+		jaegerHost  = "jaeger.domain"
+		jaegerToken = "jaeger.token"
 	)
 	configTest := config.Config{
 		Server: config.Server{
@@ -115,19 +118,20 @@ func TestLoad(t *testing.T) {
 			Db:             database,
 			MigrationsPath: config.DefaultMigrationsPostgres,
 		},
-		Audit: config.Audit{
+		Audit: config.ExternalService{
 			Enabled: true,
 			Host:    auditHost,
+			Token:   auditToken,
 		},
 		Loki: config.ExternalService{
 			Enabled: true,
 			Host:    lokiHost,
 			Token:   lokiToken,
 		},
-		Tracer: config.Tracer{
-			Enabled:    true,
-			JaegerHost: tracerHost,
-			Host:       tracerHost,
+		Jaeger: config.ExternalService{
+			Enabled: true,
+			Host:    jaegerHost,
+			Token:   jaegerToken,
 		},
 		Environment: environment,
 		Service:     service,
@@ -158,16 +162,16 @@ func TestLoad(t *testing.T) {
 					Port:           config.DefaultPostgresPort,
 					MigrationsPath: config.DefaultMigrationsPostgres,
 				},
-				Audit: config.Audit{
+				Audit: config.ExternalService{
 					Enabled: false,
 				},
 				Loki: config.ExternalService{
 					Enabled: false,
 					Host:    config.DefaultLokiHost,
 				},
-				Tracer: config.Tracer{
-					Enabled:    false,
-					JaegerHost: config.DefaultJaegerHost,
+				Jaeger: config.ExternalService{
+					Enabled: false,
+					Host:    config.DefaultJaegerHost,
 				},
 				Token: config.Token{
 					MaxAge: config.DefaultSessionMaxAge,
@@ -213,9 +217,11 @@ func TestLoadContent(t *testing.T) {
 		password    = "password"
 		username    = "username"
 		auditHost   = "audit.domain"
+		auditToken  = "audit.token"
 		lokiHost    = "loki.domain"
 		lokiToken   = "loki.token"
-		tracerHost  = "https://tracer.domain"
+		jaegerHost  = "jaeger.domain"
+		jaegerToken = "jaeger.token"
 	)
 	configTest := config.Config{
 		Server: config.Server{
@@ -251,19 +257,20 @@ func TestLoadContent(t *testing.T) {
 			Db:             database,
 			MigrationsPath: config.DefaultMigrationsPostgres,
 		},
-		Audit: config.Audit{
+		Audit: config.ExternalService{
 			Enabled: true,
 			Host:    auditHost,
+			Token:   auditToken,
 		},
 		Loki: config.ExternalService{
 			Enabled: true,
 			Host:    lokiHost,
 			Token:   lokiToken,
 		},
-		Tracer: config.Tracer{
-			Enabled:    true,
-			JaegerHost: tracerHost,
-			Host:       tracerHost,
+		Jaeger: config.ExternalService{
+			Enabled: true,
+			Host:    jaegerHost,
+			Token:   jaegerToken,
 		},
 		Environment: environment,
 		Service:     service,
@@ -293,8 +300,8 @@ func TestLoadContent(t *testing.T) {
 				Loki: config.ExternalService{
 					Host: config.DefaultLokiHost,
 				},
-				Tracer: config.Tracer{
-					JaegerHost: config.DefaultJaegerHost,
+				Jaeger: config.ExternalService{
+					Host: config.DefaultJaegerHost,
 				},
 				Token: config.Token{
 					MaxAge: config.DefaultSessionMaxAge,

--- a/config/model.go
+++ b/config/model.go
@@ -15,7 +15,7 @@ type Config struct {
 	Postgres Database `toml:"postgres" yaml:"postgres" json:"postgres,omitempty" xml:"postgres"`
 
 	Audit  ExternalService `toml:"audit" yaml:"audit" json:"audit,omitempty" xml:"audit"`
-	Jaeger ExternalService `toml:"tracer" yaml:"tracer" json:"tracer,omitempty" xml:"tracer"`
+	Jaeger ExternalService `toml:"jaeger" yaml:"jaeger" json:"jaeger,omitempty" xml:"jaeger"`
 	Loki   ExternalService `toml:"loki" yaml:"loki" json:"loki,omitempty" xml:"loki"`
 
 	Environment string `toml:"environment" yaml:"environment" json:"environment,omitempty" xml:"environment"`

--- a/config/model.go
+++ b/config/model.go
@@ -14,9 +14,9 @@ type Config struct {
 	MySql    Database `toml:"mysql" yaml:"mysql" json:"mysql,omitempty" xml:"mysql"`
 	Postgres Database `toml:"postgres" yaml:"postgres" json:"postgres,omitempty" xml:"postgres"`
 
-	Audit  Audit           `toml:"audit" yaml:"audit" json:"audit,omitempty" xml:"audit"`
+	Audit  ExternalService `toml:"audit" yaml:"audit" json:"audit,omitempty" xml:"audit"`
+	Jaeger ExternalService `toml:"tracer" yaml:"tracer" json:"tracer,omitempty" xml:"tracer"`
 	Loki   ExternalService `toml:"loki" yaml:"loki" json:"loki,omitempty" xml:"loki"`
-	Tracer Tracer          `toml:"tracer" yaml:"tracer" json:"tracer,omitempty" xml:"tracer"`
 
 	Environment string `toml:"environment" yaml:"environment" json:"environment,omitempty" xml:"environment"`
 	Service     string `toml:"service" yaml:"service" json:"service,omitempty" xml:"service"`
@@ -45,19 +45,6 @@ type Server struct {
 type Token struct {
 	MaxAge int    `toml:"max_age" yaml:"max_age" json:"max_age,omitempty" xml:"max_age"`
 	Secret string `toml:"secret" yaml:"secret" json:"secret,omitempty" xml:"secret"`
-}
-
-// Tracer holds jaeger tracer toml attributes.
-type Tracer struct {
-	Enabled    bool   `toml:"enabled" yaml:"enabled" json:"enabled,omitempty" xml:"enabled"`
-	JaegerHost string `toml:"jaeger_host" yaml:"jaeger_host" json:"jaeger_host,omitempty" xml:"jaeger_host"` // Deprecated: use Host instead
-	Host       string `toml:"host" yaml:"host" json:"host,omitempty" xml:"host"`
-}
-
-// Audit holds auditing config attributes.
-type Audit struct {
-	Enabled bool   `toml:"enabled" yaml:"enabled" json:"enabled,omitempty" xml:"enabled"`
-	Host    string `toml:"host" yaml:"host" json:"host,omitempty" xml:"host"`
 }
 
 // ExternalService holds essential external service configuration data.

--- a/config/toml/config.go
+++ b/config/toml/config.go
@@ -46,8 +46,8 @@ func LoadContent(content []byte) (config.Config, error) {
 		Loki: config.ExternalService{
 			Host: config.DefaultLokiHost,
 		},
-		Tracer: config.Tracer{
-			JaegerHost: config.DefaultJaegerHost,
+		Jaeger: config.ExternalService{
+			Host: config.DefaultJaegerHost,
 		},
 	}
 

--- a/config/toml/config_test.go
+++ b/config/toml/config_test.go
@@ -46,11 +46,17 @@ user = "username"
 [audit]
 enabled = true
 host = "audit.domain"
+token = "audit.token"
 
 [loki]
 enabled = true
 host = "loki.domain"
 token = "loki.token"
+
+[jaeger]
+enabled = true
+host = "jaeger.domain"
+token = "jaeger.token"
 
 [tracer]
 enabled = true
@@ -74,9 +80,11 @@ func TestLoad(t *testing.T) {
 		password    = "password"
 		username    = "username"
 		auditHost   = "audit.domain"
+		auditToken  = "audit.token"
 		lokiHost    = "loki.domain"
 		lokiToken   = "loki.token"
-		tracerHost  = "https://tracer.domain"
+		jaegerHost  = "jaeger.domain"
+		jaegerToken = "jaeger.token"
 	)
 	configTest := config.Config{
 		Server: config.Server{
@@ -112,19 +120,20 @@ func TestLoad(t *testing.T) {
 			Db:             database,
 			MigrationsPath: config.DefaultMigrationsPostgres,
 		},
-		Audit: config.Audit{
+		Audit: config.ExternalService{
 			Enabled: true,
 			Host:    auditHost,
+			Token:   auditToken,
 		},
 		Loki: config.ExternalService{
 			Enabled: true,
 			Host:    lokiHost,
 			Token:   lokiToken,
 		},
-		Tracer: config.Tracer{
-			Enabled:    true,
-			JaegerHost: tracerHost,
-			Host:       tracerHost,
+		Jaeger: config.ExternalService{
+			Enabled: true,
+			Host:    jaegerHost,
+			Token:   jaegerToken,
 		},
 		Environment: environment,
 		Service:     service,
@@ -158,8 +167,8 @@ func TestLoad(t *testing.T) {
 				Loki: config.ExternalService{
 					Host: config.DefaultLokiHost,
 				},
-				Tracer: config.Tracer{
-					JaegerHost: config.DefaultJaegerHost,
+				Jaeger: config.ExternalService{
+					Host: config.DefaultJaegerHost,
 				},
 				Token: config.Token{
 					MaxAge: config.DefaultSessionMaxAge,
@@ -205,9 +214,11 @@ func TestLoadContent(t *testing.T) {
 		password    = "password"
 		username    = "username"
 		auditHost   = "audit.domain"
+		auditToken  = "audit.token"
 		lokiHost    = "loki.domain"
 		lokiToken   = "loki.token"
-		tracerHost  = "https://tracer.domain"
+		jaegerHost  = "jaeger.domain"
+		jaegerToken = "jaeger.token"
 	)
 	configTest := config.Config{
 		Server: config.Server{
@@ -243,19 +254,20 @@ func TestLoadContent(t *testing.T) {
 			Db:             database,
 			MigrationsPath: config.DefaultMigrationsPostgres,
 		},
-		Audit: config.Audit{
+		Audit: config.ExternalService{
 			Enabled: true,
 			Host:    auditHost,
+			Token:   auditToken,
 		},
 		Loki: config.ExternalService{
 			Enabled: true,
 			Host:    lokiHost,
 			Token:   lokiToken,
 		},
-		Tracer: config.Tracer{
-			Enabled:    true,
-			JaegerHost: tracerHost,
-			Host:       tracerHost,
+		Jaeger: config.ExternalService{
+			Enabled: true,
+			Host:    jaegerHost,
+			Token:   jaegerToken,
 		},
 		Environment: environment,
 		Service:     service,
@@ -285,8 +297,8 @@ func TestLoadContent(t *testing.T) {
 				Loki: config.ExternalService{
 					Host: config.DefaultLokiHost,
 				},
-				Tracer: config.Tracer{
-					JaegerHost: config.DefaultJaegerHost,
+				Jaeger: config.ExternalService{
+					Host: config.DefaultJaegerHost,
 				},
 				Token: config.Token{
 					MaxAge: config.DefaultSessionMaxAge,

--- a/config/xml/config.go
+++ b/config/xml/config.go
@@ -45,8 +45,8 @@ func LoadContent(content []byte) (config.Config, error) {
 		Token: config.Token{
 			MaxAge: config.DefaultSessionMaxAge,
 		},
-		Tracer: config.Tracer{
-			JaegerHost: config.DefaultJaegerHost,
+		Jaeger: config.ExternalService{
+			Host: config.DefaultJaegerHost,
 		},
 	}
 

--- a/config/xml/config_test.go
+++ b/config/xml/config_test.go
@@ -47,17 +47,18 @@ const configContent = `<config>
     <audit>
         <enabled>true</enabled>
         <host>audit.domain</host>
+        <token>audit.token</token>
     </audit>
     <loki>
         <enabled>true</enabled>
         <host>loki.domain</host>
         <token>loki.token</token>
     </loki>
-    <tracer>
+    <jaeger>
         <enabled>true</enabled>
-        <jaeger_host>https://tracer.domain</jaeger_host>
-        <host>https://tracer.domain</host>
-    </tracer>
+        <host>jaeger.domain</host>
+        <token>jaeger.token</token>
+    </jaeger>
 </config>
 `
 
@@ -82,9 +83,11 @@ func TestLoad(t *testing.T) {
 		username     = "username"
 		xmlLocalName = "config"
 		auditHost    = "audit.domain"
+		auditToken   = "audit.token"
 		lokiHost     = "loki.domain"
 		lokiToken    = "loki.token"
-		tracerHost   = "https://tracer.domain"
+		jaegerHost   = "jaeger.domain"
+		jaegerToken  = "jaeger.token"
 	)
 	configTest := config.Config{
 		XMLName: xml.Name{
@@ -123,19 +126,20 @@ func TestLoad(t *testing.T) {
 			Db:             database,
 			MigrationsPath: config.DefaultMigrationsPostgres,
 		},
-		Audit: config.Audit{
+		Audit: config.ExternalService{
 			Enabled: true,
 			Host:    auditHost,
+			Token:   auditToken,
 		},
 		Loki: config.ExternalService{
 			Enabled: true,
 			Host:    lokiHost,
 			Token:   lokiToken,
 		},
-		Tracer: config.Tracer{
-			Enabled:    true,
-			JaegerHost: tracerHost,
-			Host:       tracerHost,
+		Jaeger: config.ExternalService{
+			Enabled: true,
+			Host:    jaegerHost,
+			Token:   jaegerToken,
 		},
 		Environment: environment,
 		Service:     service,
@@ -172,8 +176,8 @@ func TestLoad(t *testing.T) {
 				Loki: config.ExternalService{
 					Host: config.DefaultLokiHost,
 				},
-				Tracer: config.Tracer{
-					JaegerHost: config.DefaultJaegerHost,
+				Jaeger: config.ExternalService{
+					Host: config.DefaultJaegerHost,
 				},
 				Token: config.Token{
 					MaxAge: config.DefaultSessionMaxAge,
@@ -220,9 +224,11 @@ func TestLoadContent(t *testing.T) {
 		username     = "username"
 		xmlLocalName = "config"
 		auditHost    = "audit.domain"
+		auditToken   = "audit.token"
 		lokiHost     = "loki.domain"
 		lokiToken    = "loki.token"
-		tracerHost   = "https://tracer.domain"
+		jaegerHost   = "jaeger.domain"
+		jaegerToken  = "jaeger.token"
 	)
 	configTest := config.Config{
 		XMLName: xml.Name{
@@ -261,19 +267,20 @@ func TestLoadContent(t *testing.T) {
 			Db:             database,
 			MigrationsPath: config.DefaultMigrationsPostgres,
 		},
-		Audit: config.Audit{
+		Audit: config.ExternalService{
 			Enabled: true,
 			Host:    auditHost,
+			Token:   auditToken,
 		},
 		Loki: config.ExternalService{
 			Enabled: true,
 			Host:    lokiHost,
 			Token:   lokiToken,
 		},
-		Tracer: config.Tracer{
-			Enabled:    true,
-			JaegerHost: tracerHost,
-			Host:       tracerHost,
+		Jaeger: config.ExternalService{
+			Enabled: true,
+			Host:    jaegerHost,
+			Token:   jaegerToken,
 		},
 		Environment: environment,
 		Service:     service,
@@ -306,8 +313,8 @@ func TestLoadContent(t *testing.T) {
 				Loki: config.ExternalService{
 					Host: config.DefaultLokiHost,
 				},
-				Tracer: config.Tracer{
-					JaegerHost: config.DefaultJaegerHost,
+				Jaeger: config.ExternalService{
+					Host: config.DefaultJaegerHost,
 				},
 				Token: config.Token{
 					MaxAge: config.DefaultSessionMaxAge,

--- a/config/yaml/config.go
+++ b/config/yaml/config.go
@@ -46,8 +46,8 @@ func LoadContent(content []byte) (config.Config, error) {
 		Loki: config.ExternalService{
 			Host: config.DefaultLokiHost,
 		},
-		Tracer: config.Tracer{
-			JaegerHost: config.DefaultJaegerHost,
+		Jaeger: config.ExternalService{
+			Host: config.DefaultJaegerHost,
 		},
 	}
 

--- a/config/yaml/config_test.go
+++ b/config/yaml/config_test.go
@@ -46,16 +46,17 @@ postgres:
 audit:
   enabled: true
   host: "audit.domain"
+  token: "audit.token"
 
 loki:
   enabled: true
   host: "loki.domain"
   token: "loki.token"
 
-tracer:
+jaeger:
   enabled: true
-  jaeger_host: "https://tracer.domain"
-  host: "https://tracer.domain"
+  host: "jaeger.domain"
+  token: "jaeger.token"
 `
 
 const configContentInvalid = `token: 123
@@ -74,9 +75,11 @@ func TestLoadYaml(t *testing.T) {
 		password    = "password"
 		username    = "username"
 		auditHost   = "audit.domain"
+		auditToken  = "audit.token"
 		lokiHost    = "loki.domain"
 		lokiToken   = "loki.token"
-		tracerHost  = "https://tracer.domain"
+		jaegerHost  = "jaeger.domain"
+		jaegerToken = "jaeger.token"
 	)
 	configTest := config.Config{
 		Server: config.Server{
@@ -112,19 +115,20 @@ func TestLoadYaml(t *testing.T) {
 			Db:             database,
 			MigrationsPath: config.DefaultMigrationsPostgres,
 		},
-		Audit: config.Audit{
+		Audit: config.ExternalService{
 			Enabled: true,
 			Host:    auditHost,
+			Token:   auditToken,
 		},
 		Loki: config.ExternalService{
 			Enabled: true,
 			Host:    lokiHost,
 			Token:   lokiToken,
 		},
-		Tracer: config.Tracer{
-			Enabled:    true,
-			JaegerHost: tracerHost,
-			Host:       tracerHost,
+		Jaeger: config.ExternalService{
+			Enabled: true,
+			Host:    jaegerHost,
+			Token:   jaegerToken,
 		},
 		Environment: environment,
 		Service:     service,
@@ -158,8 +162,8 @@ func TestLoadYaml(t *testing.T) {
 				Loki: config.ExternalService{
 					Host: config.DefaultLokiHost,
 				},
-				Tracer: config.Tracer{
-					JaegerHost: config.DefaultJaegerHost,
+				Jaeger: config.ExternalService{
+					Host: config.DefaultJaegerHost,
 				},
 				Token: config.Token{
 					MaxAge: config.DefaultSessionMaxAge,
@@ -205,9 +209,11 @@ func TestLoadContent(t *testing.T) {
 		password    = "password"
 		username    = "username"
 		auditHost   = "audit.domain"
+		auditToken  = "audit.token"
 		lokiHost    = "loki.domain"
 		lokiToken   = "loki.token"
-		tracerHost  = "https://tracer.domain"
+		jaegerHost  = "jaeger.domain"
+		jaegerToken = "jaeger.token"
 	)
 	configTest := config.Config{
 		Server: config.Server{
@@ -243,19 +249,20 @@ func TestLoadContent(t *testing.T) {
 			Db:             database,
 			MigrationsPath: config.DefaultMigrationsPostgres,
 		},
-		Audit: config.Audit{
+		Audit: config.ExternalService{
 			Enabled: true,
 			Host:    auditHost,
+			Token:   auditToken,
 		},
 		Loki: config.ExternalService{
 			Enabled: true,
 			Host:    lokiHost,
 			Token:   lokiToken,
 		},
-		Tracer: config.Tracer{
-			Enabled:    true,
-			JaegerHost: tracerHost,
-			Host:       tracerHost,
+		Jaeger: config.ExternalService{
+			Enabled: true,
+			Host:    jaegerHost,
+			Token:   jaegerToken,
 		},
 		Environment: environment,
 		Service:     service,
@@ -285,8 +292,8 @@ func TestLoadContent(t *testing.T) {
 				Loki: config.ExternalService{
 					Host: config.DefaultLokiHost,
 				},
-				Tracer: config.Tracer{
-					JaegerHost: config.DefaultJaegerHost,
+				Jaeger: config.ExternalService{
+					Host: config.DefaultJaegerHost,
 				},
 				Token: config.Token{
 					MaxAge: config.DefaultSessionMaxAge,


### PR DESCRIPTION
* Refactor `ExternalService` model usage and remove `Audit` and `Tracer`.
* Update `Audit` and `Jaeger` in `env`, `json`, `toml`, `yaml` and `xml` load configs.
* Add `audit`, `jaeger` and `loki` to default `config.toml` file.
* Update `ExternalService`, `Audit` and `Jaeger` config documentation.
