### PR TITLE
feat: add Tempo configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Check out the following tables to know all ``Config`` parameters detailed.
 | ``[audit]``     | Auditing options config data.         | `ExternalService` | ` `     | **NO**   |
 | ``[jaeger]``    | Jaeger tracing options config data.   | `ExternalService` | ` `     | **NO**   |
 | ``[loki]``      | Grafana Loki options config data.     | `ExternalService` | ` `     | **NO**   |
+| ``[tempo]``     | Tempo tracer config data.             | `ExternalService` | ` `     | **NO**   |
 
 ### 1.1. Server type
 
@@ -71,6 +72,7 @@ and those values are described in the next table.
 | ``Audit``  | ` `                                      |
 | ``Jaeger`` | `http://localhost:14268/api/traces`      |
 | ``Loki``   | `http://localhost:3100/loki/api/v1/push` |
+| ``Tempo``  | `http://localhost:4318/v1/traces`        |
 
 ## 2. Load data
 

--- a/pkg/config/consts.go
+++ b/pkg/config/consts.go
@@ -10,4 +10,5 @@ const (
 	DefaultSessionMaxAge      = 86400 // 24 hours
 	DefaultJaegerHost         = "http://localhost:14268/api/traces"
 	DefaultLokiHost           = "http://localhost:3100/loki/api/v1/push"
+	DefaultTempoHost          = "http://localhost:4318/v1/traces"
 )

--- a/pkg/config/env/config.go
+++ b/pkg/config/env/config.go
@@ -40,6 +40,14 @@ func Load() (config.Config, error) {
 	if lokiHost == "" {
 		lokiHost = config.DefaultLokiHost
 	}
+	tempoEnabled, err := getBool("TEMPO_ENABLED")
+	if err != nil {
+		return config.Config{}, err
+	}
+	tempoHost := os.Getenv("TEMPO_HOST")
+	if tempoHost == "" {
+		tempoHost = config.DefaultTempoHost
+	}
 	jaegerEnabled, err := getBool("JAEGER_ENABLED")
 	if err != nil {
 		return config.Config{}, err
@@ -120,10 +128,15 @@ func Load() (config.Config, error) {
 			Host:    lokiHost,
 			Token:   os.Getenv("LOKI_TOKEN"),
 		},
+		Tempo: config.ExternalService{
+			Enabled: tempoEnabled,
+			Host:    tempoHost,
+			Token:   os.Getenv("TEMPO_TOKEN"),
+		},
 		Jaeger: config.ExternalService{
 			Enabled: jaegerEnabled,
 			Host:    jaegerHost,
-			Token:   os.Getenv("LOKI_TOKEN"),
+			Token:   os.Getenv("JAEGER_TOKEN"),
 		},
 		Environment: os.Getenv("ENVIRONMENT"),
 		Service:     os.Getenv("SERVICE"),

--- a/pkg/config/env/config_test.go
+++ b/pkg/config/env/config_test.go
@@ -61,8 +61,10 @@ func TestLoad(t *testing.T) {
 		auditToken  = "audit.token"
 		lokiHost    = "loki.domain"
 		lokiToken   = "loki.token"
+		tempoHost   = "tempo.domain"
+		tempoToken  = "tempo.token"
 		jaegerHost  = "jaeger.domain"
-		jaegerToken = "loki.token"
+		jaegerToken = "jaeger.token"
 	)
 	expectedCfg := config.Config{
 		Server: config.Server{
@@ -107,6 +109,11 @@ func TestLoad(t *testing.T) {
 			Enabled: true,
 			Host:    lokiHost,
 			Token:   lokiToken,
+		},
+		Tempo: config.ExternalService{
+			Enabled: true,
+			Host:    tempoHost,
+			Token:   tempoToken,
 		},
 		Jaeger: config.ExternalService{
 			Enabled: true,
@@ -170,6 +177,12 @@ func TestLoad(t *testing.T) {
 		require.NoError(t, err)
 		err = os.Setenv("LOKI_TOKEN", lokiToken)
 		require.NoError(t, err)
+		err = os.Setenv("TEMPO_ENABLED", "TRUE")
+		require.NoError(t, err)
+		err = os.Setenv("TEMPO_HOST", tempoHost)
+		require.NoError(t, err)
+		err = os.Setenv("TEMPO_TOKEN", tempoToken)
+		require.NoError(t, err)
 		err = os.Setenv("JAEGER_ENABLED", "TRUE")
 		require.NoError(t, err)
 		err = os.Setenv("JAEGER_HOST", jaegerHost)
@@ -208,6 +221,9 @@ func TestLoad(t *testing.T) {
 				"LOKI_ENABLED",
 				"LOKI_HOST",
 				"LOKI_TOKEN",
+				"TEMPO_ENABLED",
+				"TEMPO_HOST",
+				"TEMPO_TOKEN",
 				"JAEGER_ENABLED",
 				"JAEGER_HOST",
 				"JAEGER_TOKEN",
@@ -237,6 +253,9 @@ func TestLoad(t *testing.T) {
 			},
 			Loki: config.ExternalService{
 				Host: config.DefaultLokiHost,
+			},
+			Tempo: config.ExternalService{
+				Host: config.DefaultTempoHost,
 			},
 			Jaeger: config.ExternalService{
 				Host: config.DefaultJaegerHost,

--- a/pkg/config/json/config.go
+++ b/pkg/config/json/config.go
@@ -45,6 +45,9 @@ func LoadContent(content []byte) (config.Config, error) {
 		Loki: config.ExternalService{
 			Host: config.DefaultLokiHost,
 		},
+		Tempo: config.ExternalService{
+			Host: config.DefaultTempoHost,
+		},
 		Jaeger: config.ExternalService{
 			Host: config.DefaultJaegerHost,
 		},

--- a/pkg/config/json/config_test.go
+++ b/pkg/config/json/config_test.go
@@ -53,6 +53,11 @@ const configContent = `{
     "host": "loki.domain",
     "token": "loki.token"
   },
+  "tempo": {
+    "enabled": true,
+    "host": "tempo.domain",
+    "token": "tempo.token"
+  },
   "jaeger": {
     "enabled": true,
     "host": "jaeger.domain",
@@ -81,6 +86,8 @@ func TestLoad(t *testing.T) {
 		auditToken  = "audit.token"
 		lokiHost    = "loki.domain"
 		lokiToken   = "loki.token"
+		tempoHost   = "tempo.domain"
+		tempoToken  = "tempo.token"
 		jaegerHost  = "jaeger.domain"
 		jaegerToken = "jaeger.token"
 	)
@@ -128,6 +135,11 @@ func TestLoad(t *testing.T) {
 			Host:    lokiHost,
 			Token:   lokiToken,
 		},
+		Tempo: config.ExternalService{
+			Enabled: true,
+			Host:    tempoHost,
+			Token:   tempoToken,
+		},
 		Jaeger: config.ExternalService{
 			Enabled: true,
 			Host:    jaegerHost,
@@ -168,6 +180,10 @@ func TestLoad(t *testing.T) {
 				Loki: config.ExternalService{
 					Enabled: false,
 					Host:    config.DefaultLokiHost,
+				},
+				Tempo: config.ExternalService{
+					Enabled: false,
+					Host:    config.DefaultTempoHost,
 				},
 				Jaeger: config.ExternalService{
 					Enabled: false,
@@ -220,6 +236,8 @@ func TestLoadContent(t *testing.T) {
 		auditToken  = "audit.token"
 		lokiHost    = "loki.domain"
 		lokiToken   = "loki.token"
+		tempoHost   = "tempo.domain"
+		tempoToken  = "tempo.token"
 		jaegerHost  = "jaeger.domain"
 		jaegerToken = "jaeger.token"
 	)
@@ -267,6 +285,11 @@ func TestLoadContent(t *testing.T) {
 			Host:    lokiHost,
 			Token:   lokiToken,
 		},
+		Tempo: config.ExternalService{
+			Enabled: true,
+			Host:    tempoHost,
+			Token:   tempoToken,
+		},
 		Jaeger: config.ExternalService{
 			Enabled: true,
 			Host:    jaegerHost,
@@ -299,6 +322,9 @@ func TestLoadContent(t *testing.T) {
 				},
 				Loki: config.ExternalService{
 					Host: config.DefaultLokiHost,
+				},
+				Tempo: config.ExternalService{
+					Host: config.DefaultTempoHost,
 				},
 				Jaeger: config.ExternalService{
 					Host: config.DefaultJaegerHost,

--- a/pkg/config/model.go
+++ b/pkg/config/model.go
@@ -17,6 +17,7 @@ type Config struct {
 	Audit  ExternalService `toml:"audit" yaml:"audit" json:"audit,omitempty" xml:"audit"`
 	Jaeger ExternalService `toml:"jaeger" yaml:"jaeger" json:"jaeger,omitempty" xml:"jaeger"`
 	Loki   ExternalService `toml:"loki" yaml:"loki" json:"loki,omitempty" xml:"loki"`
+	Tempo  ExternalService `toml:"tempo" yaml:"tempo" json:"tempo,omitempty" xml:"tempo"`
 
 	Environment string `toml:"environment" yaml:"environment" json:"environment,omitempty" xml:"environment"`
 	Service     string `toml:"service" yaml:"service" json:"service,omitempty" xml:"service"`

--- a/pkg/config/toml/config.go
+++ b/pkg/config/toml/config.go
@@ -46,6 +46,9 @@ func LoadContent(content []byte) (config.Config, error) {
 		Loki: config.ExternalService{
 			Host: config.DefaultLokiHost,
 		},
+		Tempo: config.ExternalService{
+			Host: config.DefaultTempoHost,
+		},
 		Jaeger: config.ExternalService{
 			Host: config.DefaultJaegerHost,
 		},

--- a/pkg/config/toml/config_test.go
+++ b/pkg/config/toml/config_test.go
@@ -53,6 +53,11 @@ enabled = true
 host = "loki.domain"
 token = "loki.token"
 
+[tempo]
+enabled = true
+host = "tempo.domain"
+token = "tempo.token"
+
 [jaeger]
 enabled = true
 host = "jaeger.domain"
@@ -83,6 +88,8 @@ func TestLoad(t *testing.T) {
 		auditToken  = "audit.token"
 		lokiHost    = "loki.domain"
 		lokiToken   = "loki.token"
+		tempoHost   = "tempo.domain"
+		tempoToken  = "tempo.token"
 		jaegerHost  = "jaeger.domain"
 		jaegerToken = "jaeger.token"
 	)
@@ -130,6 +137,11 @@ func TestLoad(t *testing.T) {
 			Host:    lokiHost,
 			Token:   lokiToken,
 		},
+		Tempo: config.ExternalService{
+			Enabled: true,
+			Host:    tempoHost,
+			Token:   tempoToken,
+		},
 		Jaeger: config.ExternalService{
 			Enabled: true,
 			Host:    jaegerHost,
@@ -166,6 +178,9 @@ func TestLoad(t *testing.T) {
 				},
 				Loki: config.ExternalService{
 					Host: config.DefaultLokiHost,
+				},
+				Tempo: config.ExternalService{
+					Host: config.DefaultTempoHost,
 				},
 				Jaeger: config.ExternalService{
 					Host: config.DefaultJaegerHost,
@@ -217,6 +232,8 @@ func TestLoadContent(t *testing.T) {
 		auditToken  = "audit.token"
 		lokiHost    = "loki.domain"
 		lokiToken   = "loki.token"
+		tempoHost   = "tempo.domain"
+		tempoToken  = "tempo.token"
 		jaegerHost  = "jaeger.domain"
 		jaegerToken = "jaeger.token"
 	)
@@ -264,6 +281,11 @@ func TestLoadContent(t *testing.T) {
 			Host:    lokiHost,
 			Token:   lokiToken,
 		},
+		Tempo: config.ExternalService{
+			Enabled: true,
+			Host:    tempoHost,
+			Token:   tempoToken,
+		},
 		Jaeger: config.ExternalService{
 			Enabled: true,
 			Host:    jaegerHost,
@@ -296,6 +318,9 @@ func TestLoadContent(t *testing.T) {
 				},
 				Loki: config.ExternalService{
 					Host: config.DefaultLokiHost,
+				},
+				Tempo: config.ExternalService{
+					Host: config.DefaultTempoHost,
 				},
 				Jaeger: config.ExternalService{
 					Host: config.DefaultJaegerHost,

--- a/pkg/config/xml/config.go
+++ b/pkg/config/xml/config.go
@@ -42,6 +42,9 @@ func LoadContent(content []byte) (config.Config, error) {
 		Loki: config.ExternalService{
 			Host: config.DefaultLokiHost,
 		},
+		Tempo: config.ExternalService{
+			Host: config.DefaultTempoHost,
+		},
 		Token: config.Token{
 			MaxAge: config.DefaultSessionMaxAge,
 		},

--- a/pkg/config/xml/config_test.go
+++ b/pkg/config/xml/config_test.go
@@ -54,6 +54,11 @@ const configContent = `<config>
         <host>loki.domain</host>
         <token>loki.token</token>
     </loki>
+    <tempo>
+        <enabled>true</enabled>
+        <host>tempo.domain</host>
+        <token>tempo.token</token>
+    </tempo>
     <jaeger>
         <enabled>true</enabled>
         <host>jaeger.domain</host>
@@ -86,6 +91,8 @@ func TestLoad(t *testing.T) {
 		auditToken   = "audit.token"
 		lokiHost     = "loki.domain"
 		lokiToken    = "loki.token"
+		tempoHost    = "tempo.domain"
+		tempoToken   = "tempo.token"
 		jaegerHost   = "jaeger.domain"
 		jaegerToken  = "jaeger.token"
 	)
@@ -136,6 +143,11 @@ func TestLoad(t *testing.T) {
 			Host:    lokiHost,
 			Token:   lokiToken,
 		},
+		Tempo: config.ExternalService{
+			Enabled: true,
+			Host:    tempoHost,
+			Token:   tempoToken,
+		},
 		Jaeger: config.ExternalService{
 			Enabled: true,
 			Host:    jaegerHost,
@@ -175,6 +187,9 @@ func TestLoad(t *testing.T) {
 				},
 				Loki: config.ExternalService{
 					Host: config.DefaultLokiHost,
+				},
+				Tempo: config.ExternalService{
+					Host: config.DefaultTempoHost,
 				},
 				Jaeger: config.ExternalService{
 					Host: config.DefaultJaegerHost,
@@ -227,6 +242,8 @@ func TestLoadContent(t *testing.T) {
 		auditToken   = "audit.token"
 		lokiHost     = "loki.domain"
 		lokiToken    = "loki.token"
+		tempoHost    = "tempo.domain"
+		tempoToken   = "tempo.token"
 		jaegerHost   = "jaeger.domain"
 		jaegerToken  = "jaeger.token"
 	)
@@ -277,6 +294,11 @@ func TestLoadContent(t *testing.T) {
 			Host:    lokiHost,
 			Token:   lokiToken,
 		},
+		Tempo: config.ExternalService{
+			Enabled: true,
+			Host:    tempoHost,
+			Token:   tempoToken,
+		},
 		Jaeger: config.ExternalService{
 			Enabled: true,
 			Host:    jaegerHost,
@@ -312,6 +334,9 @@ func TestLoadContent(t *testing.T) {
 				},
 				Loki: config.ExternalService{
 					Host: config.DefaultLokiHost,
+				},
+				Tempo: config.ExternalService{
+					Host: config.DefaultTempoHost,
 				},
 				Jaeger: config.ExternalService{
 					Host: config.DefaultJaegerHost,

--- a/pkg/config/yaml/config.go
+++ b/pkg/config/yaml/config.go
@@ -46,6 +46,9 @@ func LoadContent(content []byte) (config.Config, error) {
 		Loki: config.ExternalService{
 			Host: config.DefaultLokiHost,
 		},
+		Tempo: config.ExternalService{
+			Host: config.DefaultTempoHost,
+		},
 		Jaeger: config.ExternalService{
 			Host: config.DefaultJaegerHost,
 		},

--- a/pkg/config/yaml/config_test.go
+++ b/pkg/config/yaml/config_test.go
@@ -53,6 +53,11 @@ loki:
   host: "loki.domain"
   token: "loki.token"
 
+tempo:
+  enabled: true
+  host: "tempo.domain"
+  token: "tempo.token"
+
 jaeger:
   enabled: true
   host: "jaeger.domain"
@@ -78,6 +83,8 @@ func TestLoadYaml(t *testing.T) {
 		auditToken  = "audit.token"
 		lokiHost    = "loki.domain"
 		lokiToken   = "loki.token"
+		tempoHost   = "tempo.domain"
+		tempoToken  = "tempo.token"
 		jaegerHost  = "jaeger.domain"
 		jaegerToken = "jaeger.token"
 	)
@@ -125,6 +132,11 @@ func TestLoadYaml(t *testing.T) {
 			Host:    lokiHost,
 			Token:   lokiToken,
 		},
+		Tempo: config.ExternalService{
+			Enabled: true,
+			Host:    tempoHost,
+			Token:   tempoToken,
+		},
 		Jaeger: config.ExternalService{
 			Enabled: true,
 			Host:    jaegerHost,
@@ -161,6 +173,9 @@ func TestLoadYaml(t *testing.T) {
 				},
 				Loki: config.ExternalService{
 					Host: config.DefaultLokiHost,
+				},
+				Tempo: config.ExternalService{
+					Host: config.DefaultTempoHost,
 				},
 				Jaeger: config.ExternalService{
 					Host: config.DefaultJaegerHost,
@@ -212,6 +227,8 @@ func TestLoadContent(t *testing.T) {
 		auditToken  = "audit.token"
 		lokiHost    = "loki.domain"
 		lokiToken   = "loki.token"
+		tempoHost   = "tempo.domain"
+		tempoToken  = "tempo.token"
 		jaegerHost  = "jaeger.domain"
 		jaegerToken = "jaeger.token"
 	)
@@ -259,6 +276,11 @@ func TestLoadContent(t *testing.T) {
 			Host:    lokiHost,
 			Token:   lokiToken,
 		},
+		Tempo: config.ExternalService{
+			Enabled: true,
+			Host:    tempoHost,
+			Token:   tempoToken,
+		},
 		Jaeger: config.ExternalService{
 			Enabled: true,
 			Host:    jaegerHost,
@@ -291,6 +313,9 @@ func TestLoadContent(t *testing.T) {
 				},
 				Loki: config.ExternalService{
 					Host: config.DefaultLokiHost,
+				},
+				Tempo: config.ExternalService{
+					Host: config.DefaultTempoHost,
 				},
 				Jaeger: config.ExternalService{
 					Host: config.DefaultJaegerHost,


### PR DESCRIPTION
## Changes
* Add `Tempo` model config attribute.
* Add default `Tempo` host constant.
* Add `env`, `json`, `toml`, `xml`, `yaml` Tempo load configurations.
