### PR TITLE
feat: add redis cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Check out the following tables to know all ``Config`` parameters detailed.
 | ``[loki]``       | Grafana Loki options config data.     | `ExternalService` | ` `     | **NO**   |
 | ``[tempo]``      | Tempo tracer config data.             | `ExternalService` | ` `     | **NO**   |
 | ``[prometheus]`` | Prometheus monitoring config data.    | `ExternalService` | ` `     | **NO**   |
+| ``[redis]``      | Redis cache config data.              | `ExternalService` | ` `     | **NO**   |
 
 ### 1.1. Server type
 
@@ -75,6 +76,7 @@ and those values are described in the next table.
 | ``Loki``       | `http://localhost:3100/loki/api/v1/push` |
 | ``Prometheus`` | ` `                                      |
 | ``Tempo``      | `http://localhost:4318/v1/traces`        |
+| ``Redis``      | `localhost:6379`                         |
 
 ## 2. Load data
 

--- a/pkg/config/consts.go
+++ b/pkg/config/consts.go
@@ -11,4 +11,5 @@ const (
 	DefaultJaegerHost         = "http://localhost:14268/api/traces"
 	DefaultLokiHost           = "http://localhost:3100/loki/api/v1/push"
 	DefaultTempoHost          = "http://localhost:4318/v1/traces"
+	DefaultRedisHost          = "localhost:6379"
 )

--- a/pkg/config/env/config.go
+++ b/pkg/config/env/config.go
@@ -60,6 +60,14 @@ func Load() (config.Config, error) {
 	if jaegerHost == "" {
 		jaegerHost = config.DefaultJaegerHost
 	}
+	redisEnabled, err := getBool("REDIS_ENABLED")
+	if err != nil {
+		return config.Config{}, err
+	}
+	redisHost := os.Getenv("REDIS_HOST")
+	if redisHost == "" {
+		redisHost = config.DefaultRedisHost
+	}
 
 	// Load Defaults
 	mongoDBMigrationsPath := os.Getenv("MONGODB_MIGRATIONS_PATH")
@@ -146,6 +154,11 @@ func Load() (config.Config, error) {
 			Enabled: jaegerEnabled,
 			Host:    jaegerHost,
 			Token:   os.Getenv("JAEGER_TOKEN"),
+		},
+		Redis: config.ExternalService{
+			Enabled: redisEnabled,
+			Host:    redisHost,
+			Token:   os.Getenv("REDIS_TOKEN"),
 		},
 		Environment: os.Getenv("ENVIRONMENT"),
 		Service:     os.Getenv("SERVICE"),

--- a/pkg/config/env/config_test.go
+++ b/pkg/config/env/config_test.go
@@ -67,6 +67,8 @@ func TestLoad(t *testing.T) {
 		tempoToken      = "tempo.token"
 		jaegerHost      = "jaeger.domain"
 		jaegerToken     = "jaeger.token"
+		redisHost       = "redis.domain"
+		redisToken      = "redis.token"
 	)
 	expectedCfg := config.Config{
 		Server: config.Server{
@@ -126,6 +128,11 @@ func TestLoad(t *testing.T) {
 			Enabled: true,
 			Host:    jaegerHost,
 			Token:   jaegerToken,
+		},
+		Redis: config.ExternalService{
+			Enabled: true,
+			Host:    redisHost,
+			Token:   redisToken,
 		},
 		Environment: environment,
 		Service:     service,
@@ -202,6 +209,12 @@ func TestLoad(t *testing.T) {
 		require.NoError(t, err)
 		err = os.Setenv("JAEGER_TOKEN", jaegerToken)
 		require.NoError(t, err)
+		err = os.Setenv("REDIS_ENABLED", "TRUE")
+		require.NoError(t, err)
+		err = os.Setenv("REDIS_HOST", redisHost)
+		require.NoError(t, err)
+		err = os.Setenv("REDIS_TOKEN", redisToken)
+		require.NoError(t, err)
 		err = os.Setenv("SERVICE", service)
 		require.NoError(t, err)
 		err = os.Setenv("ENVIRONMENT", environment)
@@ -243,6 +256,9 @@ func TestLoad(t *testing.T) {
 				"JAEGER_ENABLED",
 				"JAEGER_HOST",
 				"JAEGER_TOKEN",
+				"REDIS_ENABLED",
+				"REDIS_HOST",
+				"REDIS_TOKEN",
 				"SERVICE",
 				"ENVIRONMENT",
 			)
@@ -275,6 +291,9 @@ func TestLoad(t *testing.T) {
 			},
 			Jaeger: config.ExternalService{
 				Host: config.DefaultJaegerHost,
+			},
+			Redis: config.ExternalService{
+				Host: config.DefaultRedisHost,
 			},
 			Token: config.Token{
 				MaxAge: config.DefaultSessionMaxAge,

--- a/pkg/config/json/config.go
+++ b/pkg/config/json/config.go
@@ -51,6 +51,9 @@ func LoadContent(content []byte) (config.Config, error) {
 		Jaeger: config.ExternalService{
 			Host: config.DefaultJaegerHost,
 		},
+		Redis: config.ExternalService{
+			Host: config.DefaultRedisHost,
+		},
 	}
 
 	err := json.Unmarshal(content, &cfg)

--- a/pkg/config/json/config_test.go
+++ b/pkg/config/json/config_test.go
@@ -67,6 +67,11 @@ const configContent = `{
     "enabled": true,
     "host": "jaeger.domain",
     "token": "jaeger.token"
+  },
+  "redis": {
+    "enabled": true,
+    "host": "redis.domain",
+    "token": "redis.token"
   }
 }`
 
@@ -97,6 +102,8 @@ func TestLoad(t *testing.T) {
 		tempoToken      = "tempo.token"
 		jaegerHost      = "jaeger.domain"
 		jaegerToken     = "jaeger.token"
+		redisHost       = "redis.domain"
+		redisToken      = "redis.token"
 	)
 	configTest := config.Config{
 		Server: config.Server{
@@ -157,6 +164,11 @@ func TestLoad(t *testing.T) {
 			Host:    jaegerHost,
 			Token:   jaegerToken,
 		},
+		Redis: config.ExternalService{
+			Enabled: true,
+			Host:    redisHost,
+			Token:   redisToken,
+		},
 		Environment: environment,
 		Service:     service,
 	}
@@ -200,6 +212,10 @@ func TestLoad(t *testing.T) {
 				Jaeger: config.ExternalService{
 					Enabled: false,
 					Host:    config.DefaultJaegerHost,
+				},
+				Redis: config.ExternalService{
+					Enabled: false,
+					Host:    config.DefaultRedisHost,
 				},
 				Token: config.Token{
 					MaxAge: config.DefaultSessionMaxAge,
@@ -254,6 +270,8 @@ func TestLoadContent(t *testing.T) {
 		tempoToken      = "tempo.token"
 		jaegerHost      = "jaeger.domain"
 		jaegerToken     = "jaeger.token"
+		redisHost       = "redis.domain"
+		redisToken      = "redis.token"
 	)
 	configTest := config.Config{
 		Server: config.Server{
@@ -314,6 +332,11 @@ func TestLoadContent(t *testing.T) {
 			Host:    jaegerHost,
 			Token:   jaegerToken,
 		},
+		Redis: config.ExternalService{
+			Enabled: true,
+			Host:    redisHost,
+			Token:   redisToken,
+		},
 		Environment: environment,
 		Service:     service,
 	}
@@ -347,6 +370,9 @@ func TestLoadContent(t *testing.T) {
 				},
 				Jaeger: config.ExternalService{
 					Host: config.DefaultJaegerHost,
+				},
+				Redis: config.ExternalService{
+					Host: config.DefaultRedisHost,
 				},
 				Token: config.Token{
 					MaxAge: config.DefaultSessionMaxAge,

--- a/pkg/config/model.go
+++ b/pkg/config/model.go
@@ -19,6 +19,7 @@ type Config struct {
 	Loki       ExternalService `toml:"loki" yaml:"loki" json:"loki,omitempty" xml:"loki"`
 	Tempo      ExternalService `toml:"tempo" yaml:"tempo" json:"tempo,omitempty" xml:"tempo"`
 	Prometheus ExternalService `toml:"prometheus" yaml:"prometheus" json:"prometheus,omitempty" xml:"prometheus"`
+	Redis      ExternalService `toml:"redis" yaml:"redis" json:"redis,omitempty" xml:"redis"`
 
 	Environment string `toml:"environment" yaml:"environment" json:"environment,omitempty" xml:"environment"`
 	Service     string `toml:"service" yaml:"service" json:"service,omitempty" xml:"service"`

--- a/pkg/config/toml/config.go
+++ b/pkg/config/toml/config.go
@@ -52,6 +52,9 @@ func LoadContent(content []byte) (config.Config, error) {
 		Jaeger: config.ExternalService{
 			Host: config.DefaultJaegerHost,
 		},
+		Redis: config.ExternalService{
+			Host: config.DefaultRedisHost,
+		},
 	}
 
 	err := toml.Unmarshal(content, &cfg)

--- a/pkg/config/toml/config_test.go
+++ b/pkg/config/toml/config_test.go
@@ -68,6 +68,11 @@ enabled = true
 host = "jaeger.domain"
 token = "jaeger.token"
 
+[redis]
+enabled = true
+host = "redis.domain"
+token = "redis.token"
+
 [tracer]
 enabled = true
 jaeger_host = "https://tracer.domain"
@@ -99,6 +104,8 @@ func TestLoad(t *testing.T) {
 		tempoToken      = "tempo.token"
 		jaegerHost      = "jaeger.domain"
 		jaegerToken     = "jaeger.token"
+		redisHost       = "redis.domain"
+		redisToken      = "redis.token"
 	)
 	configTest := config.Config{
 		Server: config.Server{
@@ -159,6 +166,11 @@ func TestLoad(t *testing.T) {
 			Host:    jaegerHost,
 			Token:   jaegerToken,
 		},
+		Redis: config.ExternalService{
+			Enabled: true,
+			Host:    redisHost,
+			Token:   redisToken,
+		},
 		Environment: environment,
 		Service:     service,
 	}
@@ -196,6 +208,9 @@ func TestLoad(t *testing.T) {
 				},
 				Jaeger: config.ExternalService{
 					Host: config.DefaultJaegerHost,
+				},
+				Redis: config.ExternalService{
+					Host: config.DefaultRedisHost,
 				},
 				Token: config.Token{
 					MaxAge: config.DefaultSessionMaxAge,
@@ -250,6 +265,8 @@ func TestLoadContent(t *testing.T) {
 		tempoToken      = "tempo.token"
 		jaegerHost      = "jaeger.domain"
 		jaegerToken     = "jaeger.token"
+		redisHost       = "redis.domain"
+		redisToken      = "redis.token"
 	)
 	configTest := config.Config{
 		Server: config.Server{
@@ -310,6 +327,11 @@ func TestLoadContent(t *testing.T) {
 			Host:    jaegerHost,
 			Token:   jaegerToken,
 		},
+		Redis: config.ExternalService{
+			Enabled: true,
+			Host:    redisHost,
+			Token:   redisToken,
+		},
 		Environment: environment,
 		Service:     service,
 	}
@@ -343,6 +365,9 @@ func TestLoadContent(t *testing.T) {
 				},
 				Jaeger: config.ExternalService{
 					Host: config.DefaultJaegerHost,
+				},
+				Redis: config.ExternalService{
+					Host: config.DefaultRedisHost,
 				},
 				Token: config.Token{
 					MaxAge: config.DefaultSessionMaxAge,

--- a/pkg/config/xml/config.go
+++ b/pkg/config/xml/config.go
@@ -46,6 +46,9 @@ func LoadContent(content []byte) (config.XML, error) {
 			Tempo: config.ExternalService{
 				Host: config.DefaultTempoHost,
 			},
+			Redis: config.ExternalService{
+				Host: config.DefaultRedisHost,
+			},
 			Token: config.Token{
 				MaxAge: config.DefaultSessionMaxAge,
 			},

--- a/pkg/config/xml/config_test.go
+++ b/pkg/config/xml/config_test.go
@@ -69,6 +69,11 @@ const configContent = `<config>
         <host>jaeger.domain</host>
         <token>jaeger.token</token>
     </jaeger>
+    <redis>
+        <enabled>true</enabled>
+        <host>redis.domain</host>
+        <token>redis.token</token>
+    </redis>
 </config>
 `
 
@@ -102,6 +107,8 @@ func TestLoad(t *testing.T) {
 		tempoToken      = "tempo.token"
 		jaegerHost      = "jaeger.domain"
 		jaegerToken     = "jaeger.token"
+		redisHost       = "redis.domain"
+		redisToken      = "redis.token"
 	)
 	configTest := config.XML{
 		XMLName: xml.Name{
@@ -166,6 +173,11 @@ func TestLoad(t *testing.T) {
 				Host:    jaegerHost,
 				Token:   jaegerToken,
 			},
+			Redis: config.ExternalService{
+				Enabled: true,
+				Host:    redisHost,
+				Token:   redisToken,
+			},
 			Environment: environment,
 			Service:     service,
 		},
@@ -208,6 +220,9 @@ func TestLoad(t *testing.T) {
 					},
 					Jaeger: config.ExternalService{
 						Host: config.DefaultJaegerHost,
+					},
+					Redis: config.ExternalService{
+						Host: config.DefaultRedisHost,
 					},
 					Token: config.Token{
 						MaxAge: config.DefaultSessionMaxAge,
@@ -264,6 +279,8 @@ func TestLoadContent(t *testing.T) {
 		tempoToken      = "tempo.token"
 		jaegerHost      = "jaeger.domain"
 		jaegerToken     = "jaeger.token"
+		redisHost       = "redis.domain"
+		redisToken      = "redis.token"
 	)
 	configTest := config.XML{
 		XMLName: xml.Name{
@@ -328,6 +345,11 @@ func TestLoadContent(t *testing.T) {
 				Host:    jaegerHost,
 				Token:   jaegerToken,
 			},
+			Redis: config.ExternalService{
+				Enabled: true,
+				Host:    redisHost,
+				Token:   redisToken,
+			},
 			Environment: environment,
 			Service:     service,
 		},
@@ -366,6 +388,9 @@ func TestLoadContent(t *testing.T) {
 					},
 					Jaeger: config.ExternalService{
 						Host: config.DefaultJaegerHost,
+					},
+					Redis: config.ExternalService{
+						Host: config.DefaultRedisHost,
 					},
 					Token: config.Token{
 						MaxAge: config.DefaultSessionMaxAge,

--- a/pkg/config/yaml/config.go
+++ b/pkg/config/yaml/config.go
@@ -52,6 +52,9 @@ func LoadContent(content []byte) (config.Config, error) {
 		Jaeger: config.ExternalService{
 			Host: config.DefaultJaegerHost,
 		},
+		Redis: config.ExternalService{
+			Host: config.DefaultRedisHost,
+		},
 	}
 
 	err := yaml.Unmarshal(content, &cfg)

--- a/pkg/config/yaml/config_test.go
+++ b/pkg/config/yaml/config_test.go
@@ -67,6 +67,11 @@ jaeger:
   enabled: true
   host: "jaeger.domain"
   token: "jaeger.token"
+
+redis:
+  enabled: true
+  host: "redis.domain"
+  token: "redis.token"
 `
 
 const configContentInvalid = `token: 123
@@ -94,6 +99,8 @@ func TestLoadYaml(t *testing.T) {
 		tempoToken      = "tempo.token"
 		jaegerHost      = "jaeger.domain"
 		jaegerToken     = "jaeger.token"
+		redisHost       = "redis.domain"
+		redisToken      = "redis.token"
 	)
 	configTest := config.Config{
 		Server: config.Server{
@@ -154,6 +161,11 @@ func TestLoadYaml(t *testing.T) {
 			Host:    jaegerHost,
 			Token:   jaegerToken,
 		},
+		Redis: config.ExternalService{
+			Enabled: true,
+			Host:    redisHost,
+			Token:   redisToken,
+		},
 		Environment: environment,
 		Service:     service,
 	}
@@ -191,6 +203,9 @@ func TestLoadYaml(t *testing.T) {
 				},
 				Jaeger: config.ExternalService{
 					Host: config.DefaultJaegerHost,
+				},
+				Redis: config.ExternalService{
+					Host: config.DefaultRedisHost,
 				},
 				Token: config.Token{
 					MaxAge: config.DefaultSessionMaxAge,
@@ -245,6 +260,8 @@ func TestLoadContent(t *testing.T) {
 		tempoToken      = "tempo.token"
 		jaegerHost      = "jaeger.domain"
 		jaegerToken     = "jaeger.token"
+		redisHost       = "redis.domain"
+		redisToken      = "redis.token"
 	)
 	configTest := config.Config{
 		Server: config.Server{
@@ -305,6 +322,11 @@ func TestLoadContent(t *testing.T) {
 			Host:    jaegerHost,
 			Token:   jaegerToken,
 		},
+		Redis: config.ExternalService{
+			Enabled: true,
+			Host:    redisHost,
+			Token:   redisToken,
+		},
 		Environment: environment,
 		Service:     service,
 	}
@@ -338,6 +360,9 @@ func TestLoadContent(t *testing.T) {
 				},
 				Jaeger: config.ExternalService{
 					Host: config.DefaultJaegerHost,
+				},
+				Redis: config.ExternalService{
+					Host: config.DefaultRedisHost,
 				},
 				Token: config.Token{
 					MaxAge: config.DefaultSessionMaxAge,


### PR DESCRIPTION
## Changes
* Add `Redis` model config attribute.
* Add default `Redis` host constant.
* Add `env`, `json`, `toml`, `xml`, `yaml` Redis load configurations.
